### PR TITLE
Add MP4 as accepted extension as GIF replacement

### DIFF
--- a/lib/mdProcessor.js
+++ b/lib/mdProcessor.js
@@ -42,7 +42,7 @@ var FILENAME_TOC_ORDER = "toc";
 var FILENAME_TOC_JSON = "toc.json";
 var FILENAME_TOC_XML = "toc.xml";
 var FOURSPACES = "    ";
-var COPY_EXTENSIONS = [EXTENSION_HTML, EXTENSION_PDF, ".css", ".bmp", ".jpg", ".png", ".gif", ".svg", ".js", ".txt", ".xml", ".json"];
+var COPY_EXTENSIONS = [EXTENSION_HTML, EXTENSION_PDF, ".css", ".bmp", ".jpg", ".png", ".gif", ".mp4", ".svg", ".js", ".txt", ".xml", ".json"];
 
 var REGEX_ABSOLUTE_PATH = /^[/\\]/;
 var REGEX_ABSOLUTE_TOC_PATH = /^[/\\].*[/\\](toc)?$/;


### PR DESCRIPTION
Provide MP4 as an accepted extension. The purpose is to provide this as an option since they are often used in place of GIFs for motion graphics.