### PR TITLE
Allow titles in included images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project uses [semantic versioning](http://semver.org/).
 
+## [2.4.1] 2023-04-05
+Fix bug with titles in image syntax in includes extension.
+
 ## [2.4.0] 2022-11-30
 Pick up the latest marked-it-core and add support for subscript and superscript.
 

--- a/example/includesExt.js
+++ b/example/includesExt.js
@@ -58,7 +58,7 @@ process.onExit = function cleanupTempFiles(obj, data) {
 }
 
 // regex for syntax -> [Link description](<Link>)
-const link_re = /(?:\[[^\]]*\])\(([^\)]*)\)/g;
+const link_re = /(?:\[[^\]]*\])\(([^\s)]*)(?: *"[^)]*")?\)/g;
 
 function processImageMatch(match, p1, full_mdFilePath, destDir, inputDir) {
   if(match) {

--- a/example/includesExt.js
+++ b/example/includesExt.js
@@ -58,7 +58,7 @@ process.onExit = function cleanupTempFiles(obj, data) {
 }
 
 // regex for syntax -> [Link description](<Link>)
-const link_re = /(?:\[[^\]]*\])\(([^\s)]*)(?: *"[^)]*")?\)/g;
+const link_re = /(?:\[[^\]]*\])\(([^\s)]*)(?: +"[^"]*")?\)/g;
 
 function processImageMatch(match, p1, full_mdFilePath, destDir, inputDir) {
   if(match) {
@@ -242,7 +242,7 @@ const init = function (data) {
     let data = jsYaml.safeLoad(raw);
     data = preProcessJson(data, sourcePath);
 
-    // Write Json to yaml output back, useful to debug the processed output 
+    // Write Json to yaml output back, useful to debug the processed output
     const yamlOutput = jsYaml.safeDump(data);
     const outputFilename = FILENAME_INCLUDES_GEN_TOC_ORDER_YAML;
     const path_outputFilename = path.join(sourcePath, outputFilename);
@@ -309,18 +309,18 @@ function processKeyrefs(fileContent, data) {
     while(loopKeyrefPath) {
       currBaseDirName = currBaseDirName.trim();
       // Check empty string
-      if(currBaseDirName.length === 0) { 
+      if(currBaseDirName.length === 0) {
         // If the file referring to current Dir then use default keyref, which will be processed by lib/mdProcessor.js
         return fileContent;
       }
       let dirArr = currBaseDirName.split(path.sep);
       let lastIndex = dirArr.length - 1;
-  
+
       if(dirArr.length === 0 || dirArr[lastIndex] === '..') {
         // Return unchanged fileContent
         return fileContent;
       }
-  
+
       let full_keyrefPath = path.join(sourceDirPath, currBaseDirName, FILENAME_KEYREF);
       try {
         mdStat = fse.statSync(full_keyrefPath);
@@ -346,10 +346,10 @@ function processKeyrefs(fileContent, data) {
   if(!keyrefPath) {
     return fileContent;
   }
-  
+
   // Deep clone to avoid unintentional modification of globalKeyref
   const clone_globalKeyrefMapCopy = _.merge({}, globalKeyrefMapCopy);
-  
+
   try {
     localKeyrefMap.site.data = jsYaml.safeLoad(fse.readFileSync(keyrefPath));
   } catch {
@@ -698,7 +698,7 @@ file.dir.files.get =  function (filenames, data){
   // currentDir is the directory where generateHTML function is active
   const currentDir = data.sourcePath;
   // Ensure `${DIRNAME_INCLUDES}` dir is last entry so it gets processed last
-  if(true){ // Filter out DIRNAME_INCLUDE_SEGMENTS, and ensure 
+  if(true){ // Filter out DIRNAME_INCLUDE_SEGMENTS, and ensure
     // remove DIRNAME_INCLUDE_SEGMENTS to avoid processing it DIRNAME_INCLUDES processed at end
     let targetIndex = filenames.indexOf(DIRNAME_INCLUDE_SEGMENTS);
     if(targetIndex > -1) { // only splice array when item is found

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "marked-it-cli",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "marked-it-cli",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "marked-it-cli",
 	"description": "A CLI for marked-it.  Performs markdown->HTML and (optionally) TOC generation for a collection of markdown source files.",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"author": "Grant Gayed <grant_gayed@ca.ibm.com>",
 	"license": "MIT",
 	"homepage": "https://github.com/ibm/marked-it-cli",


### PR DESCRIPTION
Currently, the includes extension doesn't pull in images if if the image syntax includes a title, e.g.:

```markdown
![Enter image alt text here.](images/file-name.png "Title text that shows on hover here"){: caption="Figure 1. A description that prints on the page" caption-side="bottom"}
```

Adjusted the regex to allow for optional titles in image syntax.